### PR TITLE
Fix shadow variable linter issues

### DIFF
--- a/common.go
+++ b/common.go
@@ -541,7 +541,8 @@ func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 
 	switch discriminant {
 	case 0xff:
-		sv, err := binarySerializer.Uint64(r, littleEndian)
+		var sv uint64
+		sv, err = binarySerializer.Uint64(r, littleEndian)
 		if err != nil {
 			return 0, err
 		}
@@ -557,7 +558,8 @@ func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 		}
 
 	case 0xfe:
-		sv, err := binarySerializer.Uint32(r, littleEndian)
+		var sv uint32
+		sv, err = binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return 0, err
 		}
@@ -573,7 +575,8 @@ func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 		}
 
 	case 0xfd:
-		sv, err := binarySerializer.Uint16(r, littleEndian)
+		var sv uint16
+		sv, err = binarySerializer.Uint16(r, littleEndian)
 		if err != nil {
 			return 0, err
 		}

--- a/msgversion.go
+++ b/msgversion.go
@@ -112,7 +112,8 @@ func (msg *MsgVersion) Bsvdecode(r io.Reader, pver uint32, enc MessageEncoding) 
 	}
 
 	if buf.Len() > 0 {
-		userAgent, err := ReadVarString(buf, pver)
+		var userAgent string
+		userAgent, err = ReadVarString(buf, pver)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What Changed
- resolved variable shadowing in `common.go` and `msgversion.go`

## Why It Was Necessary
- fixes `govet` shadow warnings

## Testing Performed
- `go test ./...`
- `pre-commit run --files common.go msgversion.go` *(failed: missing ref v1.3.0 in pre-commit-golang)*

## Impact / Risk
- low

## Notifications
- @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6862d364f1d083219efd16a601a5aa24