### PR TITLE
[Chore] Ignore gosec G115 overflow rule

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -261,6 +261,11 @@
         "force-case-trailing-whitespace": 0,
         "force-err-cuddling": false,
         "strict-append": true
+      },
+      "gosec": {
+        "excludes": [
+          "G115"
+        ]
       }
     }
   },


### PR DESCRIPTION
## What Changed
- configured golangci-lint to skip gosec rule `G115` via `.golangci.json`

## Why It Was Necessary
- integer overflow conversions in the codebase are intentional; lint noise made reviews harder

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `go vet ./...`
- `golangci-lint run` *(verified G115 is no longer reported)*
- `go test ./...`

## Impact / Risk
- low; only linter configuration changed

------
https://chatgpt.com/codex/tasks/task_e_6862d3a43fd88321adf39bfdffb03647