### PR TITLE
[CI] Warn on failed auto-approve

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -183,12 +183,18 @@ jobs:
             # 5. Auto-approve minor / patch bumps
             # -----------------------------------------------------------------------
             - name: Auto-approve minor update
+              id: auto_approve
               if: steps.bump.outputs.is_minor == 'true'
+              continue-on-error: true
               uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   pull-request-number: ${{ steps.pr.outputs.number }}   # ← NEW
                   review-message: Automatically approving Dependabot minor/patch update
+
+            - name: Warn if auto-approve fails
+              if: steps.auto_approve.outcome != 'success' && steps.bump.outputs.is_minor == 'true'
+              run: echo "::warning::Auto-approval failed; GitHub Actions may not be permitted to approve its own PRs."
 
             # -----------------------------------------------------------------------
             # 6. Add the required `automerge` label (used by pascalgn/automerge)


### PR DESCRIPTION
## What Changed
- updated Dependabot auto-merge workflow to continue when the auto-approve action fails
- added explicit warning message for this scenario

## Why It Was Necessary
- auto-approve occasionally fails when executed by GitHub Actions, stopping the workflow
- continuing with a warning prevents blocked auto merges

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`

## Impact / Risk
- no functional changes to the library
- minimal risk since the workflow simply ignores a known failure case

## Notifications
- @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6862e8ffe0288321b5d789b5f51faace