### PR TITLE
[Test] Add VarInt fuzz test

### DIFF
--- a/wire_fuzz_test.go
+++ b/wire_fuzz_test.go
@@ -1,1 +1,26 @@
 package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzVarIntRoundTrip ensures encoding and then decoding a variable length
+// integer yields the original value.
+func FuzzVarIntRoundTrip(f *testing.F) {
+	seed := []uint64{0, 1, 0xfc, 0xfd, 0xffff, 0x10000, 0xffffffff, 0x100000000, 0xffffffffffffffff}
+	for _, v := range seed {
+		f.Add(v)
+	}
+
+	f.Fuzz(func(t *testing.T, val uint64) {
+		var buf bytes.Buffer
+		require.NoError(t, WriteVarInt(&buf, ProtocolVersion, val))
+
+		out, err := ReadVarInt(bytes.NewReader(buf.Bytes()), ProtocolVersion)
+		require.NoError(t, err)
+		require.Equal(t, val, out)
+	})
+}


### PR DESCRIPTION
## What Changed
- Added `FuzzVarIntRoundTrip` to `wire_fuzz_test.go` for fuzzing `WriteVarInt` and `ReadVarInt` round-trip

## Why It Was Necessary
- Introduces fuzzing to cover simple encoding/decoding paths and help detect edge cases

## Testing Performed
- `go fmt ./...`
- `goimports -w $(git ls-files '*.go')`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `pre-commit run --files wire_fuzz_test.go` *(failed: git checkout v1.3.0 not found)*

## Impact / Risk
- No breaking changes
- Minimal risk since test only exercises existing functions

------
https://chatgpt.com/codex/tasks/task_e_6862ed3ab8048321b3fe56b7a1d51d78