### PR TITLE
Move to bsv-blockchain go-bt dep

### DIFF
--- a/block_header.go
+++ b/block_header.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MaxBlockHeaderPayload is the maximum number of bytes a block header can be.

--- a/common.go
+++ b/common.go
@@ -12,7 +12,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 const (

--- a/common_test.go
+++ b/common_test.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // mainNetGenesisHash is the hash of the first block in the blockchain for the

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/bsv-blockchain/go-wire
 go 1.24
 
 require (
+	github.com/bsv-blockchain/go-bt/v2 v2.3.0
 	github.com/davecgh/go-spew v1.1.1
-	github.com/libsv/go-bt/v2 v2.2.5
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -18,5 +18,3 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/libsv/go-bt/v2 => github.com/ordishs/go-bt/v2 v2.2.22

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bsv-blockchain/go-bt/v2 v2.3.0 h1:ZEFtKV93wq59qna9/DEp4NJmVb5hZgF3h1vGXNLKMeU=
+github.com/bsv-blockchain/go-bt/v2 v2.3.0/go.mod h1:NzalErv8cCi3VDZYNLaHxnP2PiiDFIQS6dgQgBGTV4A=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,8 +11,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/libsv/go-bk v0.1.6 h1:c9CiT5+64HRDbzxPl1v/oiFmbvWZTuUYqywCf+MBs/c=
 github.com/libsv/go-bk v0.1.6/go.mod h1:khJboDoH18FPUaZlzRFKzlVN84d4YfdmlDtdX4LAjQA=
-github.com/ordishs/go-bt/v2 v2.2.22 h1:5WmTQoX74g9FADM9hpbXZOE34uep4EqeSwpIy4CbWYE=
-github.com/ordishs/go-bt/v2 v2.2.22/go.mod h1:bOaZFOoazYognJH/nfcBjuDFud1XmIc05n7bp4Tvvfk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/invvect.go
+++ b/invvect.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 const (

--- a/invvect_test.go
+++ b/invvect_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // TestInvVectStringer tests the stringized output for inventory vector types.

--- a/message.go
+++ b/message.go
@@ -12,7 +12,7 @@ import (
 	"math"
 	"unicode/utf8"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MessageHeaderSize is the number of bytes in a bitcoin message header.

--- a/message_test.go
+++ b/message_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // makeHeader is a convenience function to make a message header in the form of

--- a/msg_block.go
+++ b/msg_block.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // defaultTransactionAlloc is the default size used for the backing array

--- a/msg_block_test.go
+++ b/msg_block_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // TestBlock tests the MsgBlock API.

--- a/msg_cf_headers.go
+++ b/msg_cf_headers.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 const (

--- a/msg_cfcheckpoint.go
+++ b/msg_cfcheckpoint.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 const (

--- a/msg_cfilter.go
+++ b/msg_cfilter.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // FilterType is used to represent a filter type.

--- a/msg_extended_tx.go
+++ b/msg_extended_tx.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // ExtendedTxIn defines an extended bitcoin transaction input.

--- a/msg_extended_tx_test.go
+++ b/msg_extended_tx_test.go
@@ -13,8 +13,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // TestExtendedTx tests the MsgTx API.

--- a/msg_get_blocks.go
+++ b/msg_get_blocks.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MaxBlockLocatorsPerMsg is the maximum number of block locator hashes allowed

--- a/msg_get_blocks_test.go
+++ b/msg_get_blocks_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/msg_get_cfcheckpoint.go
+++ b/msg_get_cfcheckpoint.go
@@ -7,7 +7,7 @@ package wire
 import (
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MsgGetCFCheckpt is a request for filter headers at evenly spaced intervals

--- a/msg_get_cfheaders.go
+++ b/msg_get_cfheaders.go
@@ -7,7 +7,7 @@ package wire
 import (
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MsgGetCFHeaders is a message similar to MsgGetHeaders, but for committed

--- a/msg_get_cfilters.go
+++ b/msg_get_cfilters.go
@@ -7,7 +7,7 @@ package wire
 import (
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MaxGetCFiltersReqRange the maximum number of filters that may be requested in

--- a/msg_get_data_test.go
+++ b/msg_get_data_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/msg_get_headers.go
+++ b/msg_get_headers.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // MsgGetHeaders implements the Message interface and represents a bitcoin

--- a/msg_get_headers_test.go
+++ b/msg_get_headers_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/msg_inv_test.go
+++ b/msg_inv_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/msg_merkle_block.go
+++ b/msg_merkle_block.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // maxFlagsPerMerkleBlock returns the maximum number of flag bytes that could

--- a/msg_merkle_block_test.go
+++ b/msg_merkle_block_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/msg_not_found_test.go
+++ b/msg_not_found_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 	"github.com/stretchr/testify/require"
 )
 

--- a/msg_proto_conf.go
+++ b/msg_proto_conf.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/libsv/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2"
 )
 
 // MsgProtoconf implements the Message interface and represents a bitcoin

--- a/msg_reject.go
+++ b/msg_reject.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // RejectCode represents a numeric value by which a remote peer indicates

--- a/msg_tx.go
+++ b/msg_tx.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 const (

--- a/msg_tx_test.go
+++ b/msg_tx_test.go
@@ -12,8 +12,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/libsv/go-bt/v2/chainhash"
 )
 
 // TestTx tests the MsgTx API.

--- a/wire_benchmark_test.go
+++ b/wire_benchmark_test.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/libsv/go-bt/v2/chainhash"
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 )
 
 // genesisCoinbaseTx is the coinbase transaction for the genesis blocks for


### PR DESCRIPTION
This pull request updates the dependency from `github.com/libsv/go-bt/v2` to `github.com/bsv-blockchain/go-bt/v2` across multiple files. The changes ensure the codebase uses the latest version of the library, `v2.3.0`, and removes an outdated replacement directive in the `go.mod` file.

Dependency Update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-L7): Updated the dependency version from `github.com/libsv/go-bt/v2 v2.2.5` to `github.com/bsv-blockchain/go-bt/v2 v2.3.0`. Removed the replacement directive for `github.com/libsv/go-bt/v2`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6-L7) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L21-L22)

Codebase-wide Import Updates:

* Updated all references to `github.com/libsv/go-bt/v2/chainhash` to use `github.com/bsv-blockchain/go-bt/v2/chainhash` across multiple files, including `block_header.go`, `common.go`, `common_test.go`, `invvect.go`, `message.go`, and various `msg_*` files. [[1]](diffhunk://#diff-3679db0e56f7f5effbaf4a8cce0fcfd36a964ff1029d6bb8d0237ce5bfe5bd3cL12-R12) [[2]](diffhunk://#diff-f414a6ec09d90228aa7bafc117eaddd89d204ece70f1ee674027aa393ed63939L15-R15) [[3]](diffhunk://#diff-db8006086a10baf66c667cc9830d20488fe7857f83cc533e0d0b13cbe70d0342R16-L17) [[4]](diffhunk://#diff-0d9e22c14b0be67e0be4658a708267431fe4bac7ddfe255d47ef147deed4d517L11-R11) [[5]](diffhunk://#diff-2ce052ca28a77c3b54be26bfc568dddef91bf239253d0ad537609af1731032d4L15-R15) [[6]](diffhunk://#diff-f2573c8adbe08fce0a949dfbdb9f8653ed0e80b1ee5d9562e885e9a03357c302R17-L18) [[7]](diffhunk://#diff-40d1f530637571646c5e5b31e9e9f1360dc8127239d95f1d50aef82a4fe48a6dL12-R12) [[8]](diffhunk://#diff-ccf654bd2b1aff7668fe7067400459c36f0c79ac99e1891fd26888775d79625cR15-L16) [[9]](diffhunk://#diff-0c2cc1b9425f4b31d3694bb03fb6ae07dbb5a825fc0f6ea94df8dbf4e56ed223L11-R11) [[10]](diffhunk://#diff-8663508e2e19441ad2d844dac6f94e607eb445f34af99e8ac9b31aa080222995L12-R12) [[11]](diffhunk://#diff-24aafe663df9f4bdf517dfa5502798237750dc484ec5c77ab3aa79758d4b5666L11-R11) [[12]](diffhunk://#diff-1487e5087e673914e103652bb818b878a692a6eadc254e92d1b4f482144f60e6L12-R12) [[13]](diffhunk://#diff-7b9dbe92491a3743d60a7cff44a03855972372515b82485587db814d25c4805cR16-L17) [[14]](diffhunk://#diff-411b114ab11ee40504fa46d4558ade15a3c889ff3e301763e10e87ed139c9241L11-R11) [[15]](diffhunk://#diff-ffb4307815e23949f2e13d2a1400fcb660380e74e4440013a462f66e84ade81aR14-L15) [[16]](diffhunk://#diff-2fc1a368cdac8f5ec976318fdce658a522d03c48fd2aea16e87fc9cb96542522L10-R10) [[17]](diffhunk://#diff-fc59f8b85436a50e8ffc55e0f64e42fac3137845f0b461c88d395951f241f684L10-R10) [[18]](diffhunk://#diff-7be3d391269d0688eeddc2f8dbab8ab096dcec67b206945fddea9b85dcb257ddL10-R10)## What Changed
- 

## Why It Was Necessary
- 

## Testing Performed
- 

## Impact / Risk
-

## Notifications
- @username
