### PR TITLE
[TEST] Add helpers for command checks

### DIFF
--- a/msg_addr_test.go
+++ b/msg_addr_test.go
@@ -26,21 +26,12 @@ func TestAddr(t *testing.T) {
 	wantCmd := "addr"
 	msg := NewMsgAddr()
 
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgAddr: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for a latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
 	wantPayload := uint64(30009)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Ensure NetAddresses are added properly.
 	tcpAddr := &net.TCPAddr{IP: net.ParseIP(localhostAddr), Port: 8333}
@@ -86,26 +77,14 @@ func TestAddr(t *testing.T) {
 	// Num addresses (varInt) + max allowed addresses.
 	pver = NetAddressTimeVersion - 1
 	wantPayload = uint64(26009)
-	maxPayload = msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Ensure max payload is expected value for protocol versions before
 	// multiple addresses were allowed.
 	// Num addresses (varInt) + a single net addresses.
 	pver = MultipleAddressVersion - 1
 	wantPayload = uint64(35)
-	maxPayload = msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 }
 
 // TestAddrWire tests the MsgAddr wire encode and decode for various numbers

--- a/msg_fee_filter_test.go
+++ b/msg_fee_filter_test.go
@@ -30,20 +30,11 @@ func TestFeeFilterLatest(t *testing.T) {
 
 	// Ensure the command is expected value.
 	wantCmd := "feefilter"
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgFeeFilter: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for the latest protocol version.
 	wantPayload := uint64(8)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Test encode with latest protocol version.
 	var buf bytes.Buffer

--- a/msg_filter_add_test.go
+++ b/msg_filter_add_test.go
@@ -23,20 +23,11 @@ func TestFilterAddLatest(t *testing.T) {
 
 	// Ensure the command is expected value.
 	wantCmd := "filteradd"
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgFilterAdd: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for a latest protocol version.
 	wantPayload := uint64(523)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Test encode with latest protocol version.
 	var buf bytes.Buffer

--- a/msg_filter_clear_test.go
+++ b/msg_filter_clear_test.go
@@ -21,20 +21,11 @@ func TestFilterClearLatest(t *testing.T) {
 
 	// Ensure the command is expected value.
 	wantCmd := "filterclear"
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgFilterClear: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for the latest protocol version.
 	wantPayload := uint64(0)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 }
 
 // TestFilterClearCrossProtocol tests the MsgFilterClear API when encoding with

--- a/msg_filter_load_test.go
+++ b/msg_filter_load_test.go
@@ -23,20 +23,11 @@ func TestFilterLoadLatest(t *testing.T) {
 
 	// Ensure the command is expected value.
 	wantCmd := "filterload"
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgFilterLoad: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for the latest protocol version.
 	wantPayload := uint64(36012)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayLoadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Test encode with latest protocol version.
 	var buf bytes.Buffer

--- a/msg_get_addr_test.go
+++ b/msg_get_addr_test.go
@@ -20,21 +20,12 @@ func TestGetAddr(t *testing.T) {
 	wantCmd := "getaddr"
 	msg := NewMsgGetAddr()
 
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgGetAddr: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for latest protocol version.
 	// Num addresses (varInt) + max allowed addresses.
 	wantPayload := uint64(0)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 }
 
 // TestGetAddrWire tests the MsgGetAddr wire encode and decode for various

--- a/msg_get_blocks_test.go
+++ b/msg_get_blocks_test.go
@@ -45,22 +45,13 @@ func TestGetBlocks(t *testing.T) {
 
 	// Ensure the command is expected value.
 	wantCmd := "getblocks"
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgGetBlocks: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for the latest protocol version.
 	// Protocol version 4 bytes + num hashes (varInt) + max block locator
 	// hashes and hash stop.
 	wantPayload := uint64(16045)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Ensure block locator hashes are added properly.
 	err = msg.AddBlockLocatorHash(locatorHash)

--- a/msg_get_data_test.go
+++ b/msg_get_data_test.go
@@ -24,21 +24,12 @@ func TestGetData(t *testing.T) {
 	wantCmd := "getdata"
 	msg := NewMsgGetData()
 
-	if cmd := msg.Command(); cmd != wantCmd {
-		t.Errorf("NewMsgGetData: wrong command - got %v want %v",
-			cmd, wantCmd)
-	}
+	assertCommand(t, msg, wantCmd)
 
 	// Ensure max payload is expected value for the latest protocol version.
 	// Num inventory vectors (varInt) + max allowed inventory vectors.
 	wantPayload := uint64(1800009)
-	maxPayload := msg.MaxPayloadLength(pver)
-
-	if maxPayload != wantPayload {
-		t.Errorf("MaxPayloadLength: wrong max payload length for "+
-			"protocol version %d - got %v, want %v", pver,
-			maxPayload, wantPayload)
-	}
+	assertMaxPayload(t, msg, pver, wantPayload)
 
 	// Ensure inventory vectors are added properly.
 	hash := chainhash.Hash{}

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -1,0 +1,19 @@
+package wire
+
+import "testing"
+
+// assertCommand verifies that the message command matches the expected value.
+func assertCommand(t *testing.T, msg Message, want string) {
+	t.Helper()
+	if cmd := msg.Command(); cmd != want {
+		t.Errorf("%T: wrong command - got %v want %v", msg, cmd, want)
+	}
+}
+
+// assertMaxPayload verifies the maximum payload for the given protocol version.
+func assertMaxPayload(t *testing.T, msg Message, pver uint32, want uint64) {
+	t.Helper()
+	if got := msg.MaxPayloadLength(pver); got != want {
+		t.Errorf("MaxPayloadLength: wrong max payload length for protocol version %d - got %v, want %v", pver, got, want)
+	}
+}


### PR DESCRIPTION
## What Changed
- introduce `assertCommand` and `assertMaxPayload` helpers
- refactor several message tests to use helpers

## Why It Was Necessary
- reduces repeated code patterns in tests and improves readability

## Testing Performed
- `golangci-lint run ./...`
- `go vet ./...`
- `go test ./...`
- `pre-commit` *(failed: Could not install dependencies)*

## Impact / Risk
- no production code changes; low risk

------
https://chatgpt.com/codex/tasks/task_e_686c3aedcc708321be084b25980fed3f