### PR TITLE
[Tests] Deduplicate error message constant

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+// wrongReadErrorFmt is used to compare expected error types when reading
+// messages during tests.
+const wrongReadErrorFmt = "ReadMessage #%d wrong error got: %v <%T>, "
+
 // makeHeader is a convenience function to make a message header in the form of
 // a byte slice.  It is used to force errors when reading messages.
 func makeHeader(bsvnet BitcoinNet, command string,
@@ -355,8 +359,7 @@ func TestReadMessageWireErrors(t *testing.T) {
 
 		nr, _, _, err := ReadMessageN(r, test.pver, test.bsvnet)
 		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("ReadMessage #%d wrong error got: %v <%T>, "+
-				"want: %T", i, err, err, test.readErr)
+			t.Errorf(wrongReadErrorFmt+"want: %T", i, err, err, test.readErr)
 			continue
 		}
 
@@ -371,8 +374,7 @@ func TestReadMessageWireErrors(t *testing.T) {
 		var msgError *MessageError
 		if !errors.As(err, &msgError) {
 			if !errors.Is(err, test.readErr) {
-				t.Errorf("ReadMessage #%d wrong error got: %v <%T>, "+
-					"want: %v <%T>", i, err, err,
+				t.Errorf(wrongReadErrorFmt+"want: %v <%T>", i, err, err,
 					test.readErr, test.readErr)
 
 				continue
@@ -453,8 +455,7 @@ func TestWriteMessageWireErrors(t *testing.T) {
 		var msgError *MessageError
 		if !errors.As(err, &msgError) {
 			if !errors.Is(err, test.err) {
-				t.Errorf("ReadMessage #%d wrong error got: %v <%T>, "+
-					"want: %v <%T>", i, err, err,
+				t.Errorf(wrongReadErrorFmt+"want: %v <%T>", i, err, err,
 					test.err, test.err)
 
 				continue


### PR DESCRIPTION
## What Changed
- defined `wrongReadErrorFmt` constant in `message_test.go`
- reused constant in tests to avoid string duplication

## Why It Was Necessary
- eliminates repeated string literal flagged by linter go:S1192

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `make run-fuzz-tests`
- `pre-commit run --files message_test.go` *(failed: Could not find a version for `regex==2025.6`)*

## Impact / Risk
- no functional changes
- minimal regression risk

Assigned to @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_686c8d6fc7508321b3df925c621d03a8