### PR TITLE
[Tests] Consolidate wire error assertions

### DIFF
--- a/msg_filter_add_test.go
+++ b/msg_filter_add_test.go
@@ -6,9 +6,7 @@ package wire
 
 import (
 	"bytes"
-	"errors"
 	"io"
-	"reflect"
 	"testing"
 )
 
@@ -144,48 +142,8 @@ func TestFilterAddWireErrors(t *testing.T) {
 
 	t.Logf(runningTestsFmt, len(tests))
 
-	for i, test := range tests {
-		// Encode to wire format.
-		w := newFixedWriter(test.max)
-
-		err := test.in.BsvEncode(w, test.pver, test.enc)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BsvEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
-			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var msgError *MessageError
-		if !errors.As(err, &msgError) {
-			if !errors.Is(err, test.writeErr) {
-				t.Errorf("BsvEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
-		}
-
-		// Decode from wire format.
-		var msg MsgFilterAdd
-
-		r := newFixedReader(test.max, test.buf)
-
-		err = msg.Bsvdecode(r, test.pver, test.enc)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("Bsvdecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
-			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &msgError) {
-			if !errors.Is(err, test.readErr) {
-				t.Errorf("Bsvdecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
-		}
+	for _, test := range tests {
+		assertWireError(t, test.in, &MsgFilterAdd{}, test.buf, test.pver,
+			test.enc, test.max, test.writeErr, test.readErr)
 	}
 }

--- a/msg_get_headers_test.go
+++ b/msg_get_headers_test.go
@@ -6,7 +6,6 @@ package wire
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"reflect"
 	"testing"
@@ -378,48 +377,8 @@ func TestGetHeadersWireErrors(t *testing.T) {
 
 	t.Logf(runningTestsFmt, len(tests))
 
-	for i, test := range tests {
-		// Encode to wire format.
-		w := newFixedWriter(test.max)
-
-		err = test.in.BsvEncode(w, test.pver, test.enc)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.writeErr) {
-			t.Errorf("BsvEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
-			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		var msgError *MessageError
-		if !errors.As(err, &msgError) {
-			if !errors.Is(test.writeErr, err) {
-				t.Errorf("BsvEncode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.writeErr)
-				continue
-			}
-		}
-
-		// Decode from wire format.
-		var msg MsgGetHeaders
-
-		r := newFixedReader(test.max, test.buf)
-
-		err = msg.Bsvdecode(r, test.pver, test.enc)
-		if reflect.TypeOf(err) != reflect.TypeOf(test.readErr) {
-			t.Errorf("Bsvdecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
-			continue
-		}
-
-		// For errors which are not of type MessageError, check them for
-		// equality.
-		if !errors.As(err, &msgError) {
-			if !errors.Is(test.readErr, err) {
-				t.Errorf("Bsvdecode #%d wrong error got: %v, "+
-					"want: %v", i, err, test.readErr)
-				continue
-			}
-		}
+	for _, test := range tests {
+		assertWireError(t, test.in, &MsgGetHeaders{}, test.buf, test.pver,
+			test.enc, test.max, test.writeErr, test.readErr)
 	}
 }

--- a/msg_ping_test.go
+++ b/msg_ping_test.go
@@ -6,7 +6,6 @@ package wire
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"testing"
 
@@ -208,27 +207,8 @@ func TestPingWireErrors(t *testing.T) {
 
 	t.Logf(runningTestsFmt, len(tests))
 
-	for i, test := range tests {
-		// Encode to wire format.
-		w := newFixedWriter(test.max)
-
-		err := test.in.BsvEncode(w, test.pver, test.enc)
-		if !errors.Is(err, test.writeErr) {
-			t.Errorf("BsvEncode #%d wrong error got: %v, want: %v",
-				i, err, test.writeErr)
-			continue
-		}
-
-		// Decode from wire format.
-		var msg MsgPing
-
-		r := newFixedReader(test.max, test.buf)
-
-		err = msg.Bsvdecode(r, test.pver, test.enc)
-		if !errors.Is(err, test.readErr) {
-			t.Errorf("Bsvdecode #%d wrong error got: %v, want: %v",
-				i, err, test.readErr)
-			continue
-		}
+	for _, test := range tests {
+		assertWireError(t, test.in, &MsgPing{}, test.buf, test.pver,
+			test.enc, test.max, test.writeErr, test.readErr)
 	}
 }


### PR DESCRIPTION
## What Changed
- added new `assertWireError` helper for encoding/decoding failure checks
- replaced duplicated logic in several message tests with the helper

## Why It Was Necessary
- many tests reimplemented the same encode/decode error handling logic
- consolidating this logic simplifies tests and improves maintainability

## Testing Performed
- `go test ./...`
- `pre-commit run --files msg_filter_add_test.go msg_get_headers_test.go msg_ping_test.go msg_pong_test.go test_helpers_test.go` *(failed: could not install dependency `regex==2025.6`)*

## Impact / Risk
- no functional changes
- lower maintenance burden for future tests

------
https://chatgpt.com/codex/tasks/task_e_686d0a68ceb48321b041a933885f6a3e