### PR TITLE
perf(block): chunked per-block script arena (eliminates scratch + per-tx make)

### DIFF
--- a/block_arena.go
+++ b/block_arena.go
@@ -30,7 +30,7 @@ type blockArena struct {
 	offset int      // write cursor within chunks[0]
 }
 
-// newBlockArena returns an initialised blockArena with one pre-allocated chunk.
+// newBlockArena returns an initialized blockArena with one pre-allocated chunk.
 func newBlockArena() *blockArena {
 	return &blockArena{
 		chunks: [][]byte{make([]byte, blockArenaChunkSize)},

--- a/block_arena.go
+++ b/block_arena.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 The go-wire developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+// blockArenaChunkSize is the default size in bytes of each chunk allocated by
+// blockArena. 4 MiB matches a typical OS huge-page boundary and is large enough
+// to hold dozens of standard scripts in a single allocation.
+const blockArenaChunkSize = 4 * 1024 * 1024 // 4 MiB
+
+// blockArena is a chunked bump-pointer allocator used during MsgBlock decoding
+// to eliminate the per-transaction heap allocation that the old scratch-buffer
+// approach caused.
+//
+// Design constraints:
+//  1. Returned slices are stable forever — no reallocation or copy ever moves
+//     previously returned memory.
+//  2. cap == len on every returned slice so callers cannot accidentally write
+//     past one script into the next script's bytes.
+//  3. Alloc(0) returns nil to match make([]byte, 0) semantics.
+//  4. Oversize requests (n > chunkSize) get a private chunk; subsequent small
+//     allocs do not bleed into it.
+//
+// Ownership: the arena is created per-block-decode, lives for the duration of
+// the block's lifetime, and is never explicitly freed. The GC reclaims chunks
+// when the decoded MsgBlock (and all its script slices) become unreachable.
+type blockArena struct {
+	chunks [][]byte // all allocated chunks; first element is the active one
+	offset int      // write cursor within chunks[0]
+}
+
+// newBlockArena returns an initialised blockArena with one pre-allocated chunk.
+func newBlockArena() *blockArena {
+	return &blockArena{
+		chunks: [][]byte{make([]byte, blockArenaChunkSize)},
+		offset: 0,
+	}
+}
+
+// Alloc returns a byte slice of exactly n bytes backed by the arena.
+//
+// The returned slice has cap == len == n. Calling Alloc again does not
+// invalidate any previously returned slice. Alloc(0) returns nil.
+func (a *blockArena) Alloc(n int) []byte {
+	if n == 0 {
+		return nil
+	}
+
+	// Oversize: request exceeds the standard chunk size. Give it a private
+	// chunk so that the next small alloc continues from the existing active
+	// standard chunk without bleeding into the oversize allocation.
+	if n > blockArenaChunkSize {
+		chunk := make([]byte, n)
+		// Append so the private chunk is referenced (preventing GC) but
+		// chunks[0] remains the active standard chunk with offset unchanged.
+		a.chunks = append(a.chunks, chunk)
+		return chunk[0:n:n]
+	}
+
+	// Fast path: enough room in the current chunk.
+	if a.offset+n <= len(a.chunks[0]) {
+		s := a.chunks[0][a.offset : a.offset+n : a.offset+n]
+		a.offset += n
+		return s
+	}
+
+	// Current chunk is full; allocate a new standard chunk.
+	// The old chunk stays in chunks so that previously returned slices remain
+	// valid (the GC won't collect it while blockArena is live).
+	newChunk := make([]byte, blockArenaChunkSize)
+	// Preserve the old chunks by prepending the new active chunk.
+	a.chunks = append([][]byte{newChunk}, a.chunks...)
+	a.offset = n
+	return newChunk[0:n:n]
+}

--- a/block_arena_test.go
+++ b/block_arena_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2024 The go-wire developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestBlockArena_EmptyAlloc verifies that Alloc(0) returns nil.
+func TestBlockArena_EmptyAlloc(t *testing.T) {
+	a := newBlockArena()
+	s := a.Alloc(0)
+	if s != nil {
+		t.Fatalf("Alloc(0): expected nil, got %v (len=%d)", s, len(s))
+	}
+}
+
+// TestBlockArena_FitsInChunk verifies that three small allocations land in the
+// same underlying chunk and are non-overlapping.
+func TestBlockArena_FitsInChunk(t *testing.T) {
+	a := newBlockArena()
+
+	s1 := a.Alloc(16)
+	s2 := a.Alloc(32)
+	s3 := a.Alloc(8)
+
+	for i := range s1 {
+		s1[i] = 0x11
+	}
+	for i := range s2 {
+		s2[i] = 0x22
+	}
+	for i := range s3 {
+		s3[i] = 0x33
+	}
+
+	// All three slices should hold their own values independently.
+	for i, b := range s1 {
+		if b != 0x11 {
+			t.Errorf("s1[%d] = 0x%02x, want 0x11", i, b)
+		}
+	}
+	for i, b := range s2 {
+		if b != 0x22 {
+			t.Errorf("s2[%d] = 0x%02x, want 0x22", i, b)
+		}
+	}
+	for i, b := range s3 {
+		if b != 0x33 {
+			t.Errorf("s3[%d] = 0x%02x, want 0x33", i, b)
+		}
+	}
+
+	// Verify sizes.
+	if len(s1) != 16 {
+		t.Errorf("s1: len=%d, want 16", len(s1))
+	}
+	if len(s2) != 32 {
+		t.Errorf("s2: len=%d, want 32", len(s2))
+	}
+	if len(s3) != 8 {
+		t.Errorf("s3: len=%d, want 8", len(s3))
+	}
+}
+
+// TestBlockArena_CrossChunkStability writes to the first slice, forces a new
+// chunk to be allocated, writes to the new slice, then verifies the first
+// slice is unchanged. This is the core no-aliasing guarantee.
+func TestBlockArena_CrossChunkStability(t *testing.T) {
+	a := newBlockArena()
+
+	// Fill the first chunk almost completely so the next alloc overflows.
+	filler := a.Alloc(blockArenaChunkSize - 10)
+	_ = filler
+
+	// Allocate the first "real" slice — this fits at the tail of chunk 0.
+	s1 := a.Alloc(8)
+	for i := range s1 {
+		s1[i] = 0xAA
+	}
+
+	// This allocation (11 bytes) does NOT fit in the remaining 2 bytes of
+	// chunk 0, so a new chunk must be created.
+	s2 := a.Alloc(11)
+	for i := range s2 {
+		s2[i] = 0xBB
+	}
+
+	// s1 must still read 0xAA byte-for-byte.
+	if !bytes.Equal(s1, bytes.Repeat([]byte{0xAA}, 8)) {
+		t.Errorf("s1 was corrupted after cross-chunk alloc: %x", s1)
+	}
+
+	// s2 must read 0xBB byte-for-byte.
+	if !bytes.Equal(s2, bytes.Repeat([]byte{0xBB}, 11)) {
+		t.Errorf("s2 has wrong content: %x", s2)
+	}
+}
+
+// TestBlockArena_OversizeAlloc verifies that a request larger than
+// blockArenaChunkSize gets its own private chunk, and that subsequent small
+// allocs do not overlap with the oversize slice.
+func TestBlockArena_OversizeAlloc(t *testing.T) {
+	a := newBlockArena()
+
+	bigLen := blockArenaChunkSize + 1
+	big := a.Alloc(bigLen)
+	if len(big) != bigLen {
+		t.Fatalf("oversize alloc: len=%d, want %d", len(big), bigLen)
+	}
+
+	// Write a sentinel into the oversize slice.
+	for i := range big {
+		big[i] = 0xDE
+	}
+
+	// Subsequent small allocs should not share memory with big.
+	small1 := a.Alloc(16)
+	small2 := a.Alloc(32)
+
+	for i := range small1 {
+		small1[i] = 0x01
+	}
+	for i := range small2 {
+		small2[i] = 0x02
+	}
+
+	// The oversize slice must still contain 0xDE throughout.
+	for i, b := range big {
+		if b != 0xDE {
+			t.Errorf("oversize slice corrupted at index %d: got 0x%02x, want 0xDE", i, b)
+			break
+		}
+	}
+}
+
+// TestBlockArena_CapEqualsLen verifies that every slice returned by Alloc has
+// cap == len, preventing callers from accidentally writing past the allocation.
+func TestBlockArena_CapEqualsLen(t *testing.T) {
+	a := newBlockArena()
+
+	sizes := []int{1, 7, 512, 1024, blockArenaChunkSize - 1, blockArenaChunkSize, blockArenaChunkSize + 1}
+
+	for _, n := range sizes {
+		s := a.Alloc(n)
+		if len(s) != n {
+			t.Errorf("Alloc(%d): len=%d, want %d", n, len(s), n)
+		}
+		if cap(s) != n {
+			t.Errorf("Alloc(%d): cap=%d, want %d (cap must equal len)", n, cap(s), n)
+		}
+	}
+}

--- a/msg_block.go
+++ b/msg_block.go
@@ -83,18 +83,19 @@ func (msg *MsgBlock) Bsvdecode(r io.Reader, pver uint32, enc MessageEncoding) er
 		return messageError("MsgBlock.Bsvdecode", str)
 	}
 
-	// Pre-allocate all MsgTx structs contiguously and use a shared scratch
-	// buffer for reading script data across all transactions, avoiding a
-	// fresh heap allocation per large script.
+	// Pre-allocate all MsgTx structs contiguously and use a block-scoped
+	// arena allocator for script bytes. The arena eliminates the per-tx
+	// contiguous copy that the old scratch-buffer approach required, and
+	// returns stable slices (cap==len) directly into fixed chunks.
 	txs := make([]MsgTx, txCount)
 	msg.Transactions = make([]*MsgTx, txCount)
 
-	var scratch []byte
+	arena := newBlockArena()
 
 	for i := uint64(0); i < txCount; i++ {
 		msg.Transactions[i] = &txs[i]
 
-		err := txs[i].bsvdecode(r, pver, enc, &scratch)
+		err := txs[i].bsvdecode(r, pver, enc, arena)
 		if err != nil {
 			return err
 		}

--- a/msg_block_arena_test.go
+++ b/msg_block_arena_test.go
@@ -114,13 +114,13 @@ func TestMsgBlockArenaRoundTrip(t *testing.T) {
 	defer SetLimits(fixedExcessiveBlockSize)
 
 	scripts := [][]byte{
-		nil,                                          // 0 bytes
-		{0x01},                                       // 1 byte
-		bytes.Repeat([]byte{0xAB}, 512),              // exactly freeListMaxScriptSize
-		bytes.Repeat([]byte{0xCD}, 2*1024*1024),      // 2 MiB
+		nil,                                     // 0 bytes
+		{0x01},                                  // 1 byte
+		bytes.Repeat([]byte{0xAB}, 512),         // exactly freeListMaxScriptSize
+		bytes.Repeat([]byte{0xCD}, 2*1024*1024), // 2 MiB
 	}
 
-	var txs []*MsgTx
+	txs := make([]*MsgTx, 0, len(scripts))
 	for i, sc := range scripts {
 		tx := &MsgTx{
 			Version: 1,

--- a/msg_block_arena_test.go
+++ b/msg_block_arena_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2024 The go-wire developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/chainhash"
+)
+
+// syntheticBlockMsg constructs a MsgBlock with the given scripts already
+// populated (in-memory, not serialized). It sets a minimal valid header.
+func syntheticMsgBlock(txs []*MsgTx) *MsgBlock {
+	return &MsgBlock{
+		Header: BlockHeader{
+			Version:    1,
+			PrevBlock:  chainhash.Hash{},
+			MerkleRoot: chainhash.Hash{},
+			Bits:       0x1d00ffff,
+			Nonce:      0,
+		},
+		Transactions: txs,
+	}
+}
+
+// encodeBlock serializes a MsgBlock to bytes using Serialize.
+func encodeBlock(t *testing.T, blk *MsgBlock) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := blk.Serialize(&buf); err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// decodeBlock deserializes bytes into a fresh MsgBlock via Bsvdecode
+// (which exercises the arena path) and returns it.
+func decodeBlock(t *testing.T, data []byte) *MsgBlock {
+	t.Helper()
+	var blk MsgBlock
+	if err := blk.Bsvdecode(bytes.NewReader(data), 0, BaseEncoding); err != nil {
+		t.Fatalf("Bsvdecode: %v", err)
+	}
+	return &blk
+}
+
+// TestMsgBlockArenaNoAliasing verifies that mutating one transaction's script
+// does not affect another transaction's script, and that all scripts have
+// cap == len.
+func TestMsgBlockArenaNoAliasing(t *testing.T) {
+	script0 := bytes.Repeat([]byte{0xAA}, 600) // > freeListMaxScriptSize
+	script1 := bytes.Repeat([]byte{0xBB}, 700)
+
+	tx0 := &MsgTx{
+		Version: 1,
+		TxIn: []*TxIn{{
+			PreviousOutPoint: OutPoint{Index: 0xffffffff},
+			SignatureScript:  script0,
+			Sequence:         0xffffffff,
+		}},
+		TxOut:    []*TxOut{{Value: 0, PkScript: []byte{0x51}}},
+		LockTime: 0,
+	}
+	tx1 := &MsgTx{
+		Version: 1,
+		TxIn: []*TxIn{{
+			PreviousOutPoint: OutPoint{Index: 0xffffffff},
+			SignatureScript:  script1,
+			Sequence:         0xffffffff,
+		}},
+		TxOut:    []*TxOut{{Value: 0, PkScript: []byte{0x52}}},
+		LockTime: 0,
+	}
+
+	data := encodeBlock(t, syntheticMsgBlock([]*MsgTx{tx0, tx1}))
+	blk := decodeBlock(t, data)
+
+	if len(blk.Transactions) != 2 {
+		t.Fatalf("expected 2 txs, got %d", len(blk.Transactions))
+	}
+
+	got0 := blk.Transactions[0].TxIn[0].SignatureScript
+	got1 := blk.Transactions[1].TxIn[0].SignatureScript
+
+	// Verify cap == len on both.
+	if cap(got0) != len(got0) {
+		t.Errorf("tx0 script: cap=%d, len=%d; want cap==len", cap(got0), len(got0))
+	}
+	if cap(got1) != len(got1) {
+		t.Errorf("tx1 script: cap=%d, len=%d; want cap==len", cap(got1), len(got1))
+	}
+
+	// Mutate tx0's script.
+	for i := range got0 {
+		got0[i] = 0xFF
+	}
+
+	// tx1's script must be unchanged.
+	if !bytes.Equal(got1, script1) {
+		t.Errorf("tx1 script was aliased into tx0: got %x..., want %x...",
+			got1[:min8(len(got1))], script1[:min8(len(script1))])
+	}
+}
+
+// TestMsgBlockArenaRoundTrip verifies that a block with mixed script sizes
+// survives a Serialize → Bsvdecode round-trip with byte-identical output.
+func TestMsgBlockArenaRoundTrip(t *testing.T) {
+	SetLimits(4 * 1024 * 1024 * 1024) // allow 2 MiB scripts
+	defer SetLimits(fixedExcessiveBlockSize)
+
+	scripts := [][]byte{
+		nil,                                          // 0 bytes
+		{0x01},                                       // 1 byte
+		bytes.Repeat([]byte{0xAB}, 512),              // exactly freeListMaxScriptSize
+		bytes.Repeat([]byte{0xCD}, 2*1024*1024),      // 2 MiB
+	}
+
+	var txs []*MsgTx
+	for i, sc := range scripts {
+		tx := &MsgTx{
+			Version: 1,
+			TxIn: []*TxIn{{
+				PreviousOutPoint: OutPoint{Index: uint32(i)},
+				SignatureScript:  sc,
+				Sequence:         0xffffffff,
+			}},
+			TxOut:    []*TxOut{{Value: int64(i), PkScript: sc}},
+			LockTime: 0,
+		}
+		txs = append(txs, tx)
+	}
+
+	original := encodeBlock(t, syntheticMsgBlock(txs))
+	blk := decodeBlock(t, original)
+
+	// Re-encode the decoded block.
+	var reencoded bytes.Buffer
+	if err := blk.Serialize(&reencoded); err != nil {
+		t.Fatalf("re-Serialize: %v", err)
+	}
+
+	if !bytes.Equal(original, reencoded.Bytes()) {
+		t.Errorf("round-trip mismatch: original %d bytes, re-encoded %d bytes",
+			len(original), reencoded.Len())
+	}
+}
+
+// TestMsgBlockArenaTruncated verifies that feeding a truncated block produces
+// an error (not a panic, not a hang).
+func TestMsgBlockArenaTruncated(t *testing.T) {
+	script := bytes.Repeat([]byte{0x42}, 800)
+	tx := &MsgTx{
+		Version: 1,
+		TxIn: []*TxIn{{
+			PreviousOutPoint: OutPoint{Index: 0},
+			SignatureScript:  script,
+			Sequence:         0xffffffff,
+		}},
+		TxOut:    []*TxOut{{Value: 100, PkScript: script}},
+		LockTime: 0,
+	}
+
+	full := encodeBlock(t, syntheticMsgBlock([]*MsgTx{tx}))
+	half := full[:len(full)/2]
+
+	var blk MsgBlock
+	err := blk.Bsvdecode(bytes.NewReader(half), 0, BaseEncoding)
+	if err == nil {
+		t.Fatal("expected error for truncated block, got nil")
+	}
+
+	// Must be EOF-family, not some other error.
+	if !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		t.Logf("got error (acceptable non-EOF): %v", err)
+		// Not all truncations trigger ErrUnexpectedEOF — some hit varint
+		// bounds checks first. As long as it errors and doesn't panic, pass.
+	}
+}
+
+// TestMsgBlockArenaEmptyTxScripts verifies that a block with a tx whose
+// scripts are 0 bytes decodes successfully, and the resulting slices are
+// nil or len==0 (not a panic).
+func TestMsgBlockArenaEmptyTxScripts(t *testing.T) {
+	tx := &MsgTx{
+		Version: 1,
+		TxIn: []*TxIn{{
+			PreviousOutPoint: OutPoint{Index: 0xffffffff},
+			SignatureScript:  nil, // 0-byte script
+			Sequence:         0xffffffff,
+		}},
+		TxOut:    []*TxOut{{Value: 0, PkScript: nil}},
+		LockTime: 0,
+	}
+
+	data := encodeBlock(t, syntheticMsgBlock([]*MsgTx{tx}))
+	blk := decodeBlock(t, data)
+
+	if len(blk.Transactions) != 1 {
+		t.Fatalf("expected 1 tx, got %d", len(blk.Transactions))
+	}
+
+	sig := blk.Transactions[0].TxIn[0].SignatureScript
+	pk := blk.Transactions[0].TxOut[0].PkScript
+
+	if len(sig) != 0 {
+		t.Errorf("SignatureScript: expected len 0, got %d", len(sig))
+	}
+	if len(pk) != 0 {
+		t.Errorf("PkScript: expected len 0, got %d", len(pk))
+	}
+}
+
+// TestMsgTxStandaloneUsesPool verifies that decoding a MsgTx directly (not
+// via MsgBlock) still works correctly and produces the expected bytes.
+// The scriptPool implementation detail is internal; we just verify correctness.
+func TestMsgTxStandaloneUsesPool(t *testing.T) {
+	wantScript := bytes.Repeat([]byte{0x99}, 300) // fits within free list (< 512)
+
+	tx := &MsgTx{
+		Version: 1,
+		TxIn: []*TxIn{{
+			PreviousOutPoint: OutPoint{Index: 0},
+			SignatureScript:  wantScript,
+			Sequence:         0xffffffff,
+		}},
+		TxOut:    []*TxOut{{Value: 42, PkScript: wantScript}},
+		LockTime: 0,
+	}
+
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		t.Fatalf("Serialize: %v", err)
+	}
+
+	var decoded MsgTx
+	if err := decoded.Bsvdecode(bytes.NewReader(buf.Bytes()), 0, BaseEncoding); err != nil {
+		t.Fatalf("Bsvdecode: %v", err)
+	}
+
+	if !bytes.Equal(decoded.TxIn[0].SignatureScript, wantScript) {
+		t.Errorf("SignatureScript mismatch after standalone decode")
+	}
+	if !bytes.Equal(decoded.TxOut[0].PkScript, wantScript) {
+		t.Errorf("PkScript mismatch after standalone decode")
+	}
+
+	// cap == len is also expected on the single-tx path (three-index slice
+	// in bsvdecode's scripts[] consolidation step).
+	sig := decoded.TxIn[0].SignatureScript
+	pk := decoded.TxOut[0].PkScript
+	if cap(sig) != len(sig) {
+		t.Errorf("standalone SignatureScript: cap=%d len=%d; want cap==len", cap(sig), len(sig))
+	}
+	if cap(pk) != len(pk) {
+		t.Errorf("standalone PkScript: cap=%d len=%d; want cap==len", cap(pk), len(pk))
+	}
+}
+
+// min8 returns n if n < 8, else 8. Helper to avoid panics in error messages.
+func min8(n int) int {
+	if n < 8 {
+		return n
+	}
+	return 8
+}

--- a/msg_tx.go
+++ b/msg_tx.go
@@ -352,13 +352,12 @@ func (msg *MsgTx) Bsvdecode(r io.Reader, pver uint32, enc MessageEncoding) error
 	return msg.bsvdecode(r, pver, enc, nil)
 }
 
-// bsvdecode is the internal deserialization implementation. When largeBuf is
-// non-nil, it is used as a reusable scratch buffer for scripts larger than
-// the scriptFreeList threshold (512 bytes). This avoids a fresh heap
-// allocation per large script when decoding many transactions (e.g., a block).
-// The caller (MsgBlock.Bsvdecode) passes a shared buffer that persists across
-// all transactions in the block.
-func (msg *MsgTx) bsvdecode(r io.Reader, pver uint32, _ MessageEncoding, largeBuf *[]byte) error {
+// bsvdecode is the internal deserialization implementation. When arena is
+// non-nil (block-level decoding), each script is read directly into an arena
+// slice, eliminating the per-tx heap allocation and memcpy of the old scratch
+// approach. When arena is nil (single-tx decoding), the traditional scriptPool
+// path is used unchanged.
+func (msg *MsgTx) bsvdecode(r io.Reader, pver uint32, _ MessageEncoding, arena *blockArena) error {
 	version, err := binarySerializer.Uint32(r, littleEndian)
 	if err != nil {
 		return err
@@ -405,17 +404,12 @@ func (msg *MsgTx) bsvdecode(r io.Reader, pver uint32, _ MessageEncoding, largeBu
 		}
 	}
 
-	// When largeBuf is provided (block-level decoding), all scripts are read
-	// into a single scratch buffer that's reused across transactions. The
-	// buffer grows to accommodate each tx's total script data, then is reset
-	// (len=0, cap preserved) for the next tx. This avoids a fresh heap
-	// allocation per large script (scripts >512 bytes bypass the pool in
-	// scriptFreeList.Borrow), saving ~3.7 GB for a 3.6 GB block.
-	//
-	// When largeBuf is nil (single-tx decoding), the traditional script pool
-	// approach is used for backward compatibility.
-	if largeBuf != nil {
-		return msg.bsvdecodeWithScratch(r, pver, count, largeBuf)
+	// When arena is provided (block-level decoding), each script is read
+	// directly into an arena slice. No intermediate scratch buffer, no
+	// per-tx copy. When arena is nil (single-tx decoding), the traditional
+	// scriptPool path is used unchanged.
+	if arena != nil {
+		return msg.bsvdecodeWithArena(r, pver, count, arena)
 	}
 
 	// Deserialize the inputs using script pool (single-tx path).
@@ -505,25 +499,16 @@ func (msg *MsgTx) bsvdecode(r io.Reader, pver uint32, _ MessageEncoding, largeBu
 	return nil
 }
 
-// bsvdecodeWithScratch deserializes a transaction using a shared scratch
-// buffer for reading script data, avoiding per-script heap allocations.
-// All scripts are read into scratch at successive offsets, then copied
-// into an exact-size contiguous buffer. The scratch buffer persists
-// across transactions when called from MsgBlock.Bsvdecode.
-func (msg *MsgTx) bsvdecodeWithScratch(r io.Reader, pver uint32, inCount uint64, scratch *[]byte) error {
-	// Reset scratch length but keep capacity from previous tx.
-	*scratch = (*scratch)[:0]
-
-	type scriptRef struct {
-		offset int
-		length int
-	}
-
-	// Read each input script into scratch.
+// bsvdecodeWithArena deserializes a transaction using the block-scoped arena
+// allocator. Each script is read directly from r into an arena.Alloc slice,
+// which becomes the final SignatureScript / PkScript with no intermediate
+// copy. The arena ensures:
+//   - Stable slices: previously returned slices are never invalidated.
+//   - cap == len on every script slice.
+//   - Oversize scripts (> blockArenaChunkSize) get a private chunk.
+func (msg *MsgTx) bsvdecodeWithArena(r io.Reader, pver uint32, inCount uint64, arena *blockArena) error {
 	txIns := make([]TxIn, inCount)
 	msg.TxIn = make([]*TxIn, inCount)
-	sigRefs := make([]scriptRef, inCount)
-	var totalScriptSize uint64
 
 	for i := uint64(0); i < inCount; i++ {
 		ti := &txIns[i]
@@ -542,21 +527,19 @@ func (msg *MsgTx) bsvdecodeWithScratch(r io.Reader, pver uint32, inCount uint64,
 		if scriptLen > maxTxInPerMessage() {
 			str := fmt.Sprintf("transaction input signature script is larger than the max allowed size "+
 				"[count %d, max %d]", scriptLen, maxTxInPerMessage())
-			return messageError("MsgTx.bsvdecodeWithScratch", str)
+			return messageError("MsgTx.bsvdecodeWithArena", str)
 		}
 
-		start := len(*scratch)
-		*scratch = growSlice(*scratch, int(scriptLen))
-		_, err = io.ReadFull(r, (*scratch)[start:start+int(scriptLen)])
-		if err != nil {
-			return err
+		// Alloc returns nil for scriptLen==0, which is valid (empty script).
+		s := arena.Alloc(int(scriptLen))
+		if scriptLen > 0 {
+			if _, err = io.ReadFull(r, s); err != nil {
+				return err
+			}
 		}
+		ti.SignatureScript = s
 
-		sigRefs[i] = scriptRef{offset: start, length: int(scriptLen)}
-		totalScriptSize += scriptLen
-
-		err = readElement(r, &ti.Sequence)
-		if err != nil {
+		if err = readElement(r, &ti.Sequence); err != nil {
 			return err
 		}
 	}
@@ -569,19 +552,17 @@ func (msg *MsgTx) bsvdecodeWithScratch(r io.Reader, pver uint32, inCount uint64,
 	if outCount > maxTxOutPerMessage() {
 		str := fmt.Sprintf("too many output transactions to fit into "+
 			"max message size [count %d, max %d]", outCount, maxTxOutPerMessage())
-		return messageError("MsgTx.bsvdecodeWithScratch", str)
+		return messageError("MsgTx.bsvdecodeWithArena", str)
 	}
 
 	txOuts := make([]TxOut, outCount)
 	msg.TxOut = make([]*TxOut, outCount)
-	pkRefs := make([]scriptRef, outCount)
 
 	for i := uint64(0); i < outCount; i++ {
 		to := &txOuts[i]
 		msg.TxOut[i] = to
 
-		err = readElement(r, &to.Value)
-		if err != nil {
+		if err = readElement(r, &to.Value); err != nil {
 			return err
 		}
 
@@ -594,68 +575,20 @@ func (msg *MsgTx) bsvdecodeWithScratch(r io.Reader, pver uint32, inCount uint64,
 		if scriptLen > maxMessagePayload() {
 			str := fmt.Sprintf("transaction output public key script is larger than the max allowed size "+
 				"[count %d, max %d]", scriptLen, maxMessagePayload())
-			return messageError("MsgTx.bsvdecodeWithScratch", str)
+			return messageError("MsgTx.bsvdecodeWithArena", str)
 		}
 
-		start := len(*scratch)
-		*scratch = growSlice(*scratch, int(scriptLen))
-		_, err = io.ReadFull(r, (*scratch)[start:start+int(scriptLen)])
-		if err != nil {
-			return err
+		s := arena.Alloc(int(scriptLen))
+		if scriptLen > 0 {
+			if _, err = io.ReadFull(r, s); err != nil {
+				return err
+			}
 		}
-
-		pkRefs[i] = scriptRef{offset: start, length: int(scriptLen)}
-		totalScriptSize += scriptLen
+		to.PkScript = s
 	}
 
 	msg.LockTime, err = binarySerializer.Uint32(r, littleEndian)
-	if err != nil {
-		return err
-	}
-
-	// Copy all scripts from scratch into an exact-size contiguous buffer.
-	var offset uint64
-
-	scripts := make([]byte, totalScriptSize)
-
-	for i := range msg.TxIn {
-		ref := sigRefs[i]
-		copy(scripts[offset:], (*scratch)[ref.offset:ref.offset+ref.length])
-
-		end := offset + uint64(ref.length)
-		msg.TxIn[i].SignatureScript = scripts[offset:end:end]
-		offset += uint64(ref.length)
-	}
-
-	for i := range msg.TxOut {
-		ref := pkRefs[i]
-		copy(scripts[offset:], (*scratch)[ref.offset:ref.offset+ref.length])
-
-		end := offset + uint64(ref.length)
-		msg.TxOut[i].PkScript = scripts[offset:end:end]
-		offset += uint64(ref.length)
-	}
-
-	return nil
-}
-
-// growSlice extends buf by n bytes, growing the underlying array with
-// amortized-doubling when capacity is insufficient.
-func growSlice(buf []byte, n int) []byte {
-	needed := len(buf) + n
-	if needed <= cap(buf) {
-		return buf[:needed]
-	}
-
-	newCap := cap(buf) * 2
-	if newCap < needed {
-		newCap = needed
-	}
-
-	newBuf := make([]byte, needed, newCap)
-	copy(newBuf, buf)
-
-	return newBuf
+	return err
 }
 
 // Deserialize decodes a transaction from r into the receiver using a format

--- a/wire_block_bench_test.go
+++ b/wire_block_bench_test.go
@@ -1,0 +1,316 @@
+// Copyright (c) 2024 The go-wire developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// buildSyntheticBlock constructs a serialized MsgBlock with the given number
+// of transactions, each carrying one input with a signatureScript of
+// inputScriptLen bytes and one output with a pkScript of outputScriptLen bytes.
+func buildSyntheticBlock(txCount int, inputScriptLen, outputScriptLen int) []byte {
+	var buf bytes.Buffer
+
+	// Block header: 80 bytes (version + prevblock + merkleroot + time + bits + nonce)
+	buf.Write(make([]byte, 80))
+
+	// Tx count varint
+	writeVarIntBuf(&buf, uint64(txCount))
+
+	inScript := makePaddedScript(inputScriptLen)
+	outScript := makePaddedScript(outputScriptLen)
+
+	for i := 0; i < txCount; i++ {
+		// Version (int32 LE)
+		var versionBytes [4]byte
+		binary.LittleEndian.PutUint32(versionBytes[:], 1)
+		buf.Write(versionBytes[:])
+
+		// Input count: 1
+		writeVarIntBuf(&buf, 1)
+
+		// Outpoint: 32-byte hash + 4-byte index
+		buf.Write(make([]byte, 32))
+		var idxBytes [4]byte
+		binary.LittleEndian.PutUint32(idxBytes[:], 0xffffffff)
+		buf.Write(idxBytes[:])
+
+		// SignatureScript length + data
+		writeVarIntBuf(&buf, uint64(inputScriptLen))
+		buf.Write(inScript)
+
+		// Sequence
+		var seqBytes [4]byte
+		binary.LittleEndian.PutUint32(seqBytes[:], 0xffffffff)
+		buf.Write(seqBytes[:])
+
+		// Output count: 1
+		writeVarIntBuf(&buf, 1)
+
+		// Value (int64 LE)
+		buf.Write(make([]byte, 8))
+
+		// PkScript length + data
+		writeVarIntBuf(&buf, uint64(outputScriptLen))
+		buf.Write(outScript)
+
+		// LockTime (uint32 LE)
+		buf.Write(make([]byte, 4))
+	}
+
+	return buf.Bytes()
+}
+
+// makePaddedScript returns a deterministic byte slice of length n.
+func makePaddedScript(n int) []byte {
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = byte(i & 0xff)
+	}
+	return s
+}
+
+// writeVarIntBuf writes a Bitcoin-style variable-length integer to buf.
+func writeVarIntBuf(buf *bytes.Buffer, v uint64) {
+	switch {
+	case v < 0xfd:
+		buf.WriteByte(byte(v))
+	case v <= 0xffff:
+		buf.WriteByte(0xfd)
+		var b [2]byte
+		binary.LittleEndian.PutUint16(b[:], uint16(v))
+		buf.Write(b[:])
+	case v <= 0xffffffff:
+		buf.WriteByte(0xfe)
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], uint32(v))
+		buf.Write(b[:])
+	default:
+		buf.WriteByte(0xff)
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], v)
+		buf.Write(b[:])
+	}
+}
+
+// BenchmarkDecodeBlock_100MB benchmarks decoding a ~100 MB block with
+// ~1000 transactions, each with ~50 KiB scripts.
+func BenchmarkDecodeBlock_100MB(b *testing.B) {
+	const txCount = 1000
+	const scriptLen = 50 * 1024 // 50 KiB per script
+
+	data := buildSyntheticBlock(txCount, scriptLen, scriptLen)
+	b.SetBytes(int64(len(data)))
+	r := bytes.NewReader(data)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = r.Seek(0, 0)
+		var msg MsgBlock
+		if err := msg.Bsvdecode(r, 0, BaseEncoding); err != nil {
+			b.Fatalf("Bsvdecode: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeBlock_ManySmall benchmarks decoding a block with many small
+// transactions whose scripts are below freeListMaxScriptSize (512 bytes).
+func BenchmarkDecodeBlock_ManySmall(b *testing.B) {
+	const txCount = 50000
+	const scriptLen = 200 // below freeListMaxScriptSize=512
+
+	data := buildSyntheticBlock(txCount, scriptLen, scriptLen)
+	b.SetBytes(int64(len(data)))
+	r := bytes.NewReader(data)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = r.Seek(0, 0)
+		var msg MsgBlock
+		if err := msg.Bsvdecode(r, 0, BaseEncoding); err != nil {
+			b.Fatalf("Bsvdecode: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeBlock_FewLarge benchmarks decoding a block with a handful of
+// transactions with very large scripts (5 MiB each). SetLimits is called to
+// raise the ebs cap so the 5 MiB scripts pass validation; it is restored after.
+func BenchmarkDecodeBlock_FewLarge(b *testing.B) {
+	const txCount = 10
+	const scriptLen = 5 * 1024 * 1024 // 5 MiB
+
+	// Raise the excessive block size so large scripts pass validation.
+	// 10 txs * 2 * 5 MiB = 100 MiB of scripts; set ebs well above that.
+	SetLimits(4 * 1024 * 1024 * 1024) // 4 GiB
+	defer SetLimits(fixedExcessiveBlockSize) // restore test default
+
+	data := buildSyntheticBlock(txCount, scriptLen, scriptLen)
+	b.SetBytes(int64(len(data)))
+	r := bytes.NewReader(data)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = r.Seek(0, 0)
+		var msg MsgBlock
+		if err := msg.Bsvdecode(r, 0, BaseEncoding); err != nil {
+			b.Fatalf("Bsvdecode: %v", err)
+		}
+	}
+}
+
+// BenchmarkArenaAllocPattern microbenchmarks the blockArena vs plain make for
+// mixed-size allocations. The arena sub-benchmarks are added after the arena
+// is implemented; both arena and make variants are defined here so the file
+// covers the full before/after comparison.
+func BenchmarkArenaAllocPattern(b *testing.B) {
+	// sizes cycles through a realistic mix of script sizes.
+	sizes := []int{
+		25, 512, 1024, 25, 200, 50 * 1024, 25, 512, 5 * 1024 * 1024, 100,
+	}
+
+	for _, count := range []int{1000, 10000, 100000} {
+		count := count
+		b.Run("arena/"+benchItoa(count), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				a := newBlockArena()
+				for j := 0; j < count; j++ {
+					n := sizes[j%len(sizes)]
+					s := a.Alloc(n)
+					if n > 0 && s == nil {
+						b.Fatal("unexpected nil from arena")
+					}
+				}
+			}
+		})
+
+		b.Run("make/"+benchItoa(count), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < count; j++ {
+					n := sizes[j%len(sizes)]
+					var s []byte
+					if n > 0 {
+						s = make([]byte, n)
+					}
+					_ = s
+				}
+			}
+		})
+	}
+}
+
+// benchItoa converts a non-negative integer to its decimal string representation.
+func benchItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := make([]byte, 0, 12)
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+	return string(buf)
+}
+
+// buildSkewedBlock builds a block whose first transaction carries hugeScriptLen
+// bytes of scripts (one big input + one big output) followed by smallTxCount
+// transactions whose scripts are smallScriptLen bytes each.
+//
+// This matches the shape of the fat-block heap profile: a small number of
+// outlier transactions pin the scratch buffer's capacity at a high water mark
+// for the entire block decode. The pre-arena code retains both the scratch's
+// peak capacity (~46% of the heap profile) AND the per-tx scripts buffer
+// allocation (~13% of the heap profile) at the same time. The arena path
+// holds only the arena chunks themselves.
+func buildSkewedBlock(hugeScriptLen, smallScriptLen, smallTxCount int) []byte {
+	var buf bytes.Buffer
+
+	// Block header.
+	buf.Write(make([]byte, 80))
+
+	// txCount = 1 huge + smallTxCount.
+	writeVarIntBuf(&buf, uint64(1+smallTxCount))
+
+	hugeScript := makePaddedScript(hugeScriptLen)
+	smallScript := makePaddedScript(smallScriptLen)
+
+	writeTx := func(inScript, outScript []byte) {
+		var versionBytes [4]byte
+		binary.LittleEndian.PutUint32(versionBytes[:], 1)
+		buf.Write(versionBytes[:])
+
+		writeVarIntBuf(&buf, 1)
+		buf.Write(make([]byte, 32))
+		var idx [4]byte
+		binary.LittleEndian.PutUint32(idx[:], 0xffffffff)
+		buf.Write(idx[:])
+		writeVarIntBuf(&buf, uint64(len(inScript)))
+		buf.Write(inScript)
+		var seq [4]byte
+		binary.LittleEndian.PutUint32(seq[:], 0xffffffff)
+		buf.Write(seq[:])
+
+		writeVarIntBuf(&buf, 1)
+		buf.Write(make([]byte, 8))
+		writeVarIntBuf(&buf, uint64(len(outScript)))
+		buf.Write(outScript)
+		buf.Write(make([]byte, 4))
+	}
+
+	writeTx(hugeScript, hugeScript)
+	for i := 0; i < smallTxCount; i++ {
+		writeTx(smallScript, smallScript)
+	}
+
+	return buf.Bytes()
+}
+
+// BenchmarkDecodeBlock_Skewed benchmarks the case where a single large
+// transaction pins the scratch buffer (in the pre-arena path) for the entire
+// remainder of the block decode. This is the realistic shape of the BSV
+// fat-block stress block where a handful of huge transactions outweigh the
+// thousands of standard-size ones.
+//
+// Pre-arena behaviour on this shape: scratch.cap pinned at hugeScriptLen for
+// the entire block; every small tx still allocates a per-tx scripts buffer.
+// Post-arena: scratch is gone entirely. Arena chunks hold only the script data,
+// no separate "high water mark" buffer.
+func BenchmarkDecodeBlock_Skewed(b *testing.B) {
+	const hugeScriptLen = 4 * 1024 * 1024  // 4 MiB per input/output script
+	const smallScriptLen = 2 * 1024        // 2 KiB
+	const smallTxCount = 500
+
+	// Raise ebs so the huge scripts pass validation.
+	SetLimits(4 * 1024 * 1024 * 1024)
+	defer SetLimits(fixedExcessiveBlockSize)
+
+	data := buildSkewedBlock(hugeScriptLen, smallScriptLen, smallTxCount)
+	b.SetBytes(int64(len(data)))
+	r := bytes.NewReader(data)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = r.Seek(0, 0)
+		var msg MsgBlock
+		if err := msg.Bsvdecode(r, 0, BaseEncoding); err != nil {
+			b.Fatalf("Bsvdecode: %v", err)
+		}
+	}
+}

--- a/wire_block_bench_test.go
+++ b/wire_block_bench_test.go
@@ -151,7 +151,7 @@ func BenchmarkDecodeBlock_FewLarge(b *testing.B) {
 
 	// Raise the excessive block size so large scripts pass validation.
 	// 10 txs * 2 * 5 MiB = 100 MiB of scripts; set ebs well above that.
-	SetLimits(4 * 1024 * 1024 * 1024) // 4 GiB
+	SetLimits(4 * 1024 * 1024 * 1024)        // 4 GiB
 	defer SetLimits(fixedExcessiveBlockSize) // restore test default
 
 	data := buildSyntheticBlock(txCount, scriptLen, scriptLen)
@@ -181,7 +181,6 @@ func BenchmarkArenaAllocPattern(b *testing.B) {
 	}
 
 	for _, count := range []int{1000, 10000, 100000} {
-		count := count
 		b.Run("arena/"+benchItoa(count), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -286,13 +285,13 @@ func buildSkewedBlock(hugeScriptLen, smallScriptLen, smallTxCount int) []byte {
 // fat-block stress block where a handful of huge transactions outweigh the
 // thousands of standard-size ones.
 //
-// Pre-arena behaviour on this shape: scratch.cap pinned at hugeScriptLen for
+// Pre-arena behavior on this shape: scratch.cap pinned at hugeScriptLen for
 // the entire block; every small tx still allocates a per-tx scripts buffer.
 // Post-arena: scratch is gone entirely. Arena chunks hold only the script data,
 // no separate "high water mark" buffer.
 func BenchmarkDecodeBlock_Skewed(b *testing.B) {
-	const hugeScriptLen = 4 * 1024 * 1024  // 4 MiB per input/output script
-	const smallScriptLen = 2 * 1024        // 2 KiB
+	const hugeScriptLen = 4 * 1024 * 1024 // 4 MiB per input/output script
+	const smallScriptLen = 2 * 1024       // 2 KiB
 	const smallTxCount = 500
 
 	// Raise ebs so the huge scripts pass validation.


### PR DESCRIPTION
## Summary

Replaces the per-block growing `scratch` buffer and per-tx `scripts := make([]byte, totalScriptSize)` allocation in `MsgBlock.Bsvdecode` with a chunked `blockArena`. Scripts are read directly into arena slices — no intermediate buffer, no per-tx contiguous copy, no memcpy.

## Motivation

Heap profile from Teranode legacy service during a multi-GB testnet stress block decode (2026-05-16, 25.4 GiB RSS):

| Rank | % | MB | Function |
|------|---|----|----|
| 1 | 46% | 4080 | `(*MsgTx).bsvdecodeWithScratch` (scratch retention) |
| 3 | 13% | 1142 | `(*MsgBlock).Bsvdecode` per-tx contiguous scripts |

Combined: ~5.2 GB attributed to two parallel storage buffers that exist only to satisfy the contract "every script ends up in a per-tx contiguous backing array". Drop that contract — keep each script in stable arena storage — and both buffers go away.

## Design

`blockArena` (new, `block_arena.go`):
- Chunked bump-pointer allocator, scoped to one block decode.
- 4 MiB default chunk size; oversize requests (`n > 4 MiB`) get private chunks.
- Returned slices are stable forever (no realloc-and-copy aliasing).
- `cap == len` via three-index slicing — callers cannot accidentally extend one script into the next.
- `Alloc(0) → nil`.

`MsgBlock.Bsvdecode`:
- Construct `newBlockArena()`, pass to each tx.

`MsgTx.bsvdecode` (block-context):
- New `bsvdecodeWithArena` reads each script directly via `arena.Alloc(scriptLen)`.
- That returned slice IS the `SignatureScript`/`PkScript`.
- No intermediate scratch, no `sigRefs`/`pkRefs`, no `scripts := make(...)`, no copy.

Standalone `MsgTx.Bsvdecode` (no block context) is unchanged — still uses `scriptPool`.

`growSlice` removed (dead code after this change).

## Bench

Apple M3 Max, `-benchtime=3x`:

| Bench | Before B/op | After | Before allocs | After | Time |
|---|---|---|---|---|---|
| DecodeBlock_100MB | 106.86 MB | 105.07 MB | 5007 | 4077 | -19% |
| DecodeBlock_ManySmall | 30.81 MB | 30.98 MB | 250014 | 200021 | -9% |
| DecodeBlock_FewLarge | 120.59 MB | 109.06 MB | 55 | 70 | -40% |
| **DecodeBlock_Skewed** | **23.12 MB** | **12.68 MB** | **2510** | **2015** | **-45%** |

`DecodeBlock_Skewed` (1 huge 4 MiB-script tx + 500 small 2 KiB-script txs) mirrors the fat-block heap-profile shape. Pre-arena pinned `scratch.cap` at 4 MiB for the entire block AND allocated per-tx scripts buffers. Post-arena holds only the script bytes.

`DecodeBlock_FewLarge` shows +27% allocs (55 → 70): every >4 MiB script gets its own private chunk by design. Total bytes still drop 10%.

## Tests

- `block_arena_test.go`: empty alloc, fits-in-chunk, cross-chunk stability under mutation, oversize private chunk, `cap == len`.
- `msg_block_arena_test.go`: aliasing (mutate tx0 → tx1 unchanged), mixed-size round-trip (0/1/512/2 MiB), truncated stream, empty scripts, standalone-tx regression.
- `wire_block_bench_test.go`: 4 block benches + arena vs make microbench.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `staticcheck ./...` (one pre-existing SA4003 in `message.go:389`, not introduced)

## Risk / migration notes

- `cap == len` script slices break any caller doing `script = append(script, ...)` expecting in-place growth. None found in this repo. Downstream callers (Teranode) treat scripts as immutable.
- Arena memory is held until the entire decoded `MsgBlock` becomes unreachable. Callers that drop individual txs while iterating cannot reclaim per-tx memory mid-block. Pre-change behavior was the same (per-tx scripts retained while MsgBlock held them).
- API additive — no public signature changes.