### PR TITLE
fix: linter issues and upgraded deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/crypto v0.51.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
-golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/msg_block_arena_test.go
+++ b/msg_block_arena_test.go
@@ -28,8 +28,8 @@ func syntheticMsgBlock(txs []*MsgTx) *MsgBlock {
 	}
 }
 
-// encodeBlock serializes a MsgBlock to bytes using Serialize.
-func encodeBlock(t *testing.T, blk *MsgBlock) []byte {
+// serializeBlock serializes a MsgBlock to bytes using Serialize.
+func serializeBlock(t *testing.T, blk *MsgBlock) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	if err := blk.Serialize(&buf); err != nil {
@@ -77,7 +77,7 @@ func TestMsgBlockArenaNoAliasing(t *testing.T) {
 		LockTime: 0,
 	}
 
-	data := encodeBlock(t, syntheticMsgBlock([]*MsgTx{tx0, tx1}))
+	data := serializeBlock(t, syntheticMsgBlock([]*MsgTx{tx0, tx1}))
 	blk := decodeBlock(t, data)
 
 	if len(blk.Transactions) != 2 {
@@ -135,7 +135,7 @@ func TestMsgBlockArenaRoundTrip(t *testing.T) {
 		txs = append(txs, tx)
 	}
 
-	original := encodeBlock(t, syntheticMsgBlock(txs))
+	original := serializeBlock(t, syntheticMsgBlock(txs))
 	blk := decodeBlock(t, original)
 
 	// Re-encode the decoded block.
@@ -165,7 +165,7 @@ func TestMsgBlockArenaTruncated(t *testing.T) {
 		LockTime: 0,
 	}
 
-	full := encodeBlock(t, syntheticMsgBlock([]*MsgTx{tx}))
+	full := serializeBlock(t, syntheticMsgBlock([]*MsgTx{tx}))
 	half := full[:len(full)/2]
 
 	var blk MsgBlock
@@ -197,7 +197,7 @@ func TestMsgBlockArenaEmptyTxScripts(t *testing.T) {
 		LockTime: 0,
 	}
 
-	data := encodeBlock(t, syntheticMsgBlock([]*MsgTx{tx}))
+	data := serializeBlock(t, syntheticMsgBlock([]*MsgTx{tx}))
 	blk := decodeBlock(t, data)
 
 	if len(blk.Transactions) != 1 {

--- a/wire_block_bench_test.go
+++ b/wire_block_bench_test.go
@@ -13,7 +13,7 @@ import (
 // buildSyntheticBlock constructs a serialized MsgBlock with the given number
 // of transactions, each carrying one input with a signatureScript of
 // inputScriptLen bytes and one output with a pkScript of outputScriptLen bytes.
-func buildSyntheticBlock(txCount int, inputScriptLen, outputScriptLen int) []byte {
+func buildSyntheticBlock(txCount, inputScriptLen, outputScriptLen int) []byte {
 	var buf bytes.Buffer
 
 	// Block header: 80 bytes (version + prevblock + merkleroot + time + bits + nonce)


### PR DESCRIPTION
This pull request includes minor updates to improve code clarity and dependency management. The most important changes are a dependency update and a function renaming for consistency.

Dependency update:
* Updated the `golang.org/x/crypto` dependency from version `v0.50.0` to `v0.51.0` in `go.mod`, ensuring the project uses the latest security and bug fixes.

Test code improvements:
* Renamed the helper function from `encodeBlock` to `serializeBlock` in `msg_block_arena_test.go` for clearer naming, and updated all test usages accordingly. [[1]](diffhunk://#diff-451b1fa4fffcbee69b1a0abae276d2903952d5877b638156986ca5ed5f4b18f7L31-R32) [[2]](diffhunk://#diff-451b1fa4fffcbee69b1a0abae276d2903952d5877b638156986ca5ed5f4b18f7L80-R80) [[3]](diffhunk://#diff-451b1fa4fffcbee69b1a0abae276d2903952d5877b638156986ca5ed5f4b18f7L138-R138) [[4]](diffhunk://#diff-451b1fa4fffcbee69b1a0abae276d2903952d5877b638156986ca5ed5f4b18f7L168-R168) [[5]](diffhunk://#diff-451b1fa4fffcbee69b1a0abae276d2903952d5877b638156986ca5ed5f4b18f7L200-R200)
* Simplified the parameter list of `buildSyntheticBlock` in `wire_block_bench_test.go` for improved readability.