### PR TITLE
fix(protoconf): bound stream-policies length before allocating + fuzz decoders

### DIFF
--- a/message_decode_fuzz_test.go
+++ b/message_decode_fuzz_test.go
@@ -1,0 +1,54 @@
+package wire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// allDecodeCommands lists every command makeEmptyMessage understands, so the
+// fuzzer exercises each message type's Bsvdecode.
+var allDecodeCommands = []string{
+	CmdVersion, CmdVerAck, CmdGetAddr, CmdAddr, CmdGetBlocks, CmdInv,
+	CmdGetData, CmdNotFound, CmdBlock, CmdTx, CmdExtendedTx, CmdGetHeaders,
+	CmdHeaders, CmdPing, CmdPong, CmdMemPool, CmdFilterAdd, CmdFilterClear,
+	CmdFilterLoad, CmdMerkleBlock, CmdReject, CmdSendHeaders, CmdFeeFilter,
+	CmdGetCFilters, CmdGetCFHeaders, CmdGetCFCheckpt, CmdCFilter, CmdCFHeaders,
+	CmdCFCheckpt, CmdProtoconf, CmdExtMsg, CmdSendcmpct, CmdAuthch, CmdAuthresp,
+	CmdCreateStream, CmdStreamAck,
+}
+
+// FuzzMessageDecode feeds arbitrary bytes to every wire message decoder
+// (Message.Bsvdecode) — the code path that runs on untrusted data received from
+// a peer. A decoder must never panic or attempt an unbounded allocation from a
+// length/count field in the payload (e.g. a 9-byte varint claiming 2^64 items).
+// ReadMessageWithEncodingN bounds the *payload size* per message type before
+// dispatch, but a count varint inside can still exceed the item data actually
+// present, so the per-decoder count bounds are what this targets.
+func FuzzMessageDecode(f *testing.F) {
+	// A varint encoding 0xFFFFFFFFFFFFFFFF — a hostile "count" with no items
+	// behind it. A decoder that does make([]T, count) without bounding it first
+	// panics ("makeslice: len out of range") or OOMs here.
+	hugeCount := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+	for _, c := range allDecodeCommands {
+		f.Add(c, []byte{})
+		f.Add(c, make([]byte, 24))
+		f.Add(c, hugeCount)
+	}
+
+	// Regression: a protoconf whose stream-policies length field is huge
+	// previously panicked via an unbounded make([]byte, vi) in
+	// MsgProtoconf.Bsvdecode. (testdata/ is gitignored here, so the crasher
+	// lives as an explicit seed.)
+	f.Add(CmdProtoconf, []byte("00000\xff00000000"))
+
+	f.Fuzz(func(_ *testing.T, command string, data []byte) {
+		msg, err := makeEmptyMessage(command)
+		if err != nil {
+			return // not a registered command
+		}
+
+		// Must not panic on arbitrary peer bytes; an error return is fine.
+		_ = msg.Bsvdecode(bytes.NewReader(data), ProtocolVersion, LatestEncoding)
+	})
+}

--- a/msg_proto_conf.go
+++ b/msg_proto_conf.go
@@ -92,6 +92,16 @@ func (msg *MsgProtoconf) Bsvdecode(r io.Reader, pver uint32, _ MessageEncoding) 
 			return err
 		}
 
+		// Bound the stream-policies length read from the peer before
+		// allocating: an unbounded make([]byte, vi) panics ("makeslice: len
+		// out of range") or exhausts memory on a crafted length. Mirrors the
+		// cap ReadVarString applies.
+		if uint64(vi) > maxMessagePayload() {
+			str := fmt.Sprintf("stream policies length too long "+
+				"[count %d, max %d]", uint64(vi), maxMessagePayload())
+			return messageError("MsgProtoconf.Bsvdecode", str)
+		}
+
 		b := make([]byte, vi)
 
 		_, err = io.ReadFull(r, b)


### PR DESCRIPTION
## Bug (remotely-triggerable DoS)

`MsgProtoconf.Bsvdecode` reads the stream-policies length as a varint from the peer and allocates it without a bound:

```go
_, err = vi.ReadFrom(r)
...
b := make([]byte, vi)   // vi is attacker-controlled, unbounded
```

A `protoconf` message with a crafted length field makes the receiver **panic** (`makeslice: len out of range`) or exhaust memory. Since `Bsvdecode` runs on untrusted bytes received from a peer, any connected peer can trigger it.

## Fix

Bound the length against `maxMessagePayload()` before allocating — the same cap `ReadVarString` already applies in this package. A crafted length now returns a clean `messageError` instead of panicking.

## Tests

Adds **`FuzzMessageDecode`**, a fuzz harness that feeds arbitrary bytes to every message decoder via `makeEmptyMessage` + `Bsvdecode` (the untrusted-peer-data path). It found this bug in ~8 seconds.

`testdata/` is gitignored in this repo, so the discovered crasher is embedded as an explicit `f.Add` regression seed — it reproduces the panic on the pre-fix code (run as a normal `go test`) and passes after.

## Verification

- Regression seed panics on pre-fix code, passes after.
- `go test ./` (full suite), `go vet`, `gofmt`, `golangci-lint` (new issues) — all clean.
- Re-fuzzing for 90s after the fix (~15M execs) found no further crashers across all 36 decoders.

Found during a security pass on the BSV wire-protocol parsers (the remotely-reachable attack surface).
